### PR TITLE
Allow for up to 30 mins to sync data on shutdown

### DIFF
--- a/zram-config.service
+++ b/zram-config.service
@@ -9,6 +9,7 @@ TimeoutSec=300
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/zram-config "start"
 ExecStop=/usr/local/sbin/zram-config "stop"
+TimeoutStopSec=1800s
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
There's more reports the default gracetime on shutdown (5 mins) is not enough in some cases.

Fixes: #51 

Signed-off-by: Markus Storm <markus.storm@gmx.net>