### PR TITLE
Try to avoid 'zramctl --find' race conditon

### DIFF
--- a/zram-config
+++ b/zram-config
@@ -10,6 +10,7 @@ createZdevice() {
 
 	if [[ -z $RAM_DEV ]]; then
 		echo "createZdevice: Failed to find an open zram device, trying one more time!" >> "$ZLOG"
+		sleep 0.2
 		RAM_DEV="$(zramctl --find --size "$DISK_SIZE" --algorithm "$ALG" | tr -dc '0-9')"
 		if [[ -z $RAM_DEV ]]; then
 			echo "createZdevice: Failed to find an open zram device. Exiting!" | tee -a "$ZLOG"


### PR DESCRIPTION
[As reported earlier but at the wrong location](https://github.com/ecdye/zram-config/issues/71#issuecomment-1106548005) I experienced strange behaviour when testing most recent `zram-config` version with freshly released Ubuntu 22.04/armhf on an Raspberry Pi 4.

It seems there's some sort of a race condition when using `zramctl --find` and it clearly doesn't help when there's no delay between the two `zramctl --find` calls. Quick check with a `sleep 0.2` in between seemed to fix it.

To get more reliable data I added an automatic reboot to the install to check `zram-config` behaviour:

    root@ubuntu:/home/ubuntu# cat /etc/rc.local 
    #!/bin/bash
    
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    
    echo >>/var/log/zram-status.log
    date >>/var/log/zram-status.log
    sleep 60
    zramctl | grep -v NAME >>/var/log/zram-status.log
    systemctl status zram-config.service | grep busy >>/var/log/zram-status.log
    reboot

Test with an unaltered `/usr/local/sbin/zram-config` showed the following behaviour walking through 10 boot attempts:

  * 5 times both zram devices have been created without an error
  * 2 times both zram devives have been created with at least one error
  * 3 times only `/dev/zram0` has been created while recording two `zramctl: /dev/zram0: failed to reset: Device or resource busy` errors

`/var/log/zram-status.log`:

    Fri Apr 22 19:15:03 CEST 2022
    /dev/zram1 lzo-rle       150M 16.5M  2.6M    5M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:17:00 CEST 2022
    /dev/zram0 lzo-rle       150M 16.6M  2.6M  5.1M       4 /opt/zram/zram0
    Apr 22 19:17:00 ubuntu zram-config[719]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    Apr 22 19:17:00 ubuntu zram-config[728]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:19:02 CEST 2022
    /dev/zram1 lzo-rle       150M 16.8M  2.7M  5.2M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:19:02 ubuntu zram-config[714]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:21:00 CEST 2022
    /dev/zram1 lzo-rle       150M 14.9M  2.7M  5.1M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:22:59 CEST 2022
    /dev/zram0 lzo-rle       150M 15.1M  2.8M  5.2M       4 /opt/zram/zram0
    Apr 22 19:22:59 ubuntu zram-config[709]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    Apr 22 19:22:59 ubuntu zram-config[721]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:24:57 CEST 2022
    /dev/zram1 lzo-rle       150M 15.9M  2.9M  5.5M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:26:56 CEST 2022
    /dev/zram0 lzo-rle       150M 15.5M  2.9M  5.4M       4 /opt/zram/zram0
    Apr 22 19:26:56 ubuntu zram-config[712]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    Apr 22 19:26:56 ubuntu zram-config[726]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:28:53 CEST 2022
    /dev/zram1 lzo-rle       150M 15.6M    3M  5.5M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:30:53 CEST 2022
    /dev/zram1 lzo-rle       150M 16.4M  3.1M  5.7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:32:50 CEST 2022
    /dev/zram1 lzo-rle       150M  16M  3.1M  5.7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M   4K   87B    4K       4 [SWAP]
    Apr 22 19:32:50 ubuntu zram-config[716]: zramctl: /dev/zram0: failed to reset: Device or resource busy

Adding a simple `sleep 0.1` between the two `zramctl --find` calls improves things while still 6 errors occur but in 11 tests always both zram devices could be created:

    Fri Apr 22 19:34:47 CEST 2022
    /dev/zram1 lzo-rle       150M 16.9M  3.3M    6M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:36:46 CEST 2022
    /dev/zram1 lzo-rle       150M 18.5M  3.3M    6M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:36:46 ubuntu zram-config[705]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:38:46 CEST 2022
    /dev/zram1 lzo-rle       150M 16.6M  3.4M    6M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:40:44 CEST 2022
    /dev/zram1 lzo-rle       150M 16.8M  3.4M  6.1M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:42:42 CEST 2022
    /dev/zram1 lzo-rle       150M  17M  3.5M  6.1M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M   4K   87B    4K       4 [SWAP]
    Apr 22 19:42:41 ubuntu zram-config[709]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:44:40 CEST 2022
    /dev/zram1 lzo-rle       150M 17.2M  3.6M  6.3M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:44:40 ubuntu zram-config[714]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:46:38 CEST 2022
    /dev/zram1 lzo-rle       150M 17.3M  3.6M  6.3M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:46:38 ubuntu zram-config[712]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:48:38 CEST 2022
    /dev/zram1 lzo-rle       150M 17.6M  3.7M  6.4M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:48:38 ubuntu zram-config[703]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:50:37 CEST 2022
    /dev/zram1 lzo-rle       150M 17.8M  3.8M  6.6M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:52:36 CEST 2022
    /dev/zram1 lzo-rle       150M  18M  3.9M  6.7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M   4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 19:54:35 CEST 2022
    /dev/zram1 lzo-rle       150M 18.7M    4M  6.9M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:54:35 ubuntu zram-config[721]: zramctl: /dev/zram0: failed to reset: Device or resource busy

The 0.1 second delay between both `zramctl` calls seems to do the job. Now for some extra safety headroom testing with `sleep 0.2`:

    Fri Apr 22 19:56:32 CEST 2022
    /dev/zram1 lzo-rle       150M 20.5M  4.1M    7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:56:32 ubuntu zram-config[699]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 19:58:30 CEST 2022
    /dev/zram1 lzo-rle       150M 18.5M  4.1M  6.9M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 19:58:30 ubuntu zram-config[713]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:00:27 CEST 2022
    /dev/zram1 lzo-rle       150M 18.7M  4.1M    7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 20:02:26 CEST 2022
    /dev/zram1 lzo-rle       150M 18.9M  4.2M  7.1M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:02:26 ubuntu zram-config[709]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:04:25 CEST 2022
    /dev/zram1 lzo-rle       150M 19.1M  4.3M  7.2M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:04:25 ubuntu zram-config[714]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:06:23 CEST 2022
    /dev/zram1 lzo-rle       150M 19.3M  4.3M  7.3M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 20:08:22 CEST 2022
    /dev/zram1 lzo-rle       150M 19.4M  4.4M  7.4M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:08:22 ubuntu zram-config[710]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:10:20 CEST 2022
    /dev/zram1 lzo-rle       150M 19.6M  4.5M  7.5M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:10:20 ubuntu zram-config[710]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:12:18 CEST 2022
    /dev/zram1 lzo-rle       150M 20.5M  4.6M  7.8M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    
    Fri Apr 22 20:14:15 CEST 2022
    /dev/zram1 lzo-rle       150M 20.1M  4.6M  7.7M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:14:15 ubuntu zram-config[708]: zramctl: /dev/zram0: failed to reset: Device or resource busy
    
    Fri Apr 22 20:16:12 CEST 2022
    /dev/zram1 lzo-rle       150M 20.9M  4.8M    8M       4 /opt/zram/zram1
    /dev/zram0 lzo-rle       750M    4K   87B    4K       4 [SWAP]
    Apr 22 20:16:11 ubuntu zram-config[705]: zramctl: /dev/zram0: failed to reset: Device or resource busy

Again 11 times both zram devices created and 8 times an error at the first `zramctl --find` attempt occured (most probably not related to the delay but 'result variation' since most likely happening at the 1st `zram --find` call)

I'll run the test for the next few hours (~30 reboots per hour) and report back.