### PR TITLE
Skip unwanted sync-targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This will ensure that any changes are properly synced to the persistent storage 
 Run `sudo zram-config sync` to sync any changes in the zram filesystems managed by zram-config to persistent storage.
 If you have concerns about losing data due to sudden power loss you could use this to ensure that changes are synced to disk periodically.
 
-If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional option to the sync parameter like `sudo zram-config sync "/example/targetfolder`
+If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional option to the sync parameter like `sudo zram-config sync `/example/targetfolder`
 
 A default sync service that will sync files to disk every night can be installed by running the following.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This will ensure that any changes are properly synced to the persistent storage 
 Run `sudo zram-config sync` to sync any changes in the zram filesystems managed by zram-config to persistent storage.
 If you have concerns about losing data due to sudden power loss you could use this to ensure that changes are synced to disk periodically.
 
+If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional option to the sync parameter like `sudo zram-config sync "/example/targetfolder`
+
 A default sync service that will sync files to disk every night can be installed by running the following.
 
 ``` shell

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This will ensure that any changes are properly synced to the persistent storage 
 Run `sudo zram-config sync` to sync any changes in the zram filesystems managed by zram-config to persistent storage.
 If you have concerns about losing data due to sudden power loss you could use this to ensure that changes are synced to disk periodically.
 
-If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional option to the sync parameter like `sudo zram-config sync `/example/targetfolder`
+If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional option to the sync parameter like `sudo zram-config sync "/example/targetfolder"`
 
 A default sync service that will sync files to disk every night can be installed by running the following.
 

--- a/doc/src/zram-config.md
+++ b/doc/src/zram-config.md
@@ -2,7 +2,7 @@
 title: zram-config
 section: 1
 header: zram-config
-date: February 2025
+date: August 2025
 ---
 
 # NAME
@@ -11,7 +11,7 @@ zram-config - A complete utility for swap, directories, and logs to reduce SD, N
 
 # SYNOPSIS
 
-**zram-config** {start|stop|sync}
+**zram-config** {start|stop|sync [target]}
 
 # DESCRIPTION
 
@@ -41,6 +41,9 @@ Stops any running devices configured by zram-config and syncs the changes back t
 ## *sync*
 
 Syncs any changes back to persistent storage. This ensures no data will be lost in the case of sudden power loss.
+
+If you sync only one single target instead of all targets as specified in the /etc/ztab, you can add an additional
+option [target] to the sync parameter.
 
 # OPTIONS
 

--- a/service/SystemD/zsync.service
+++ b/service/SystemD/zsync.service
@@ -7,5 +7,5 @@ Wants=zsync.timer
 Type=oneshot
 ExecStart=/usr/local/sbin/zram-config "sync" 
 
-# Example for OpenHABian persistence-sync only
-# ExecStart=/usr/local/sbin/zram-config "sync" "/var/lib/openhab/persistence"
+# Example for sync only one single target
+# ExecStart=/usr/local/sbin/zram-config "sync" "/example/targetfolder"

--- a/service/SystemD/zsync.service
+++ b/service/SystemD/zsync.service
@@ -6,3 +6,6 @@ Wants=zsync.timer
 [Service]
 Type=oneshot
 ExecStart=/usr/local/sbin/zram-config "sync" 
+
+# Example for OpenHABian persistence-sync only
+# ExecStart=/usr/local/sbin/zram-config "sync" "/var/lib/openhab/persistence"

--- a/zram-config
+++ b/zram-config
@@ -451,6 +451,9 @@ case "$1" in
             log "WRN" "Skipping sync, zram-config not running."
             exit 0
         fi
+        if [[ $# -gt 1 ]]; then
+            ONLY_TARGET="$2"
+        fi
         tac "$TMPDIR"/zram-device-list > "$TMPDIR"/zram-device-list.rev
         while read -r line; do
             case "$line" in
@@ -469,11 +472,13 @@ case "$1" in
                     set -- $line
                     case "$1" in
                         dir|log)
-                            ZRAM_DEV="$2"
-                            TARGET_DIR="$3"
-                            BIND_DIR="$(basename "$TARGET_DIR").bind"
-                            [[ -z $SHUTDOWN ]] && serviceConfiguration "stop"
-                            syncZdir
+                            if [[ -z "$ONLY_TARGET" ]] || [[ $ONLY_TARGET == $3 ]]; then
+                                ZRAM_DEV="$2"
+                                TARGET_DIR="$3"
+                                BIND_DIR="$(basename "$TARGET_DIR").bind"
+                                [[ -z $SHUTDOWN ]] && serviceConfiguration "stop"
+                                syncZdir
+                            fi
                             ;;
                     esac
                     ;;
@@ -483,7 +488,7 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: zram-config {start|stop|sync}"
+        echo "Usage: zram-config {start|stop|sync} [target]"
         exit 0
         ;;
 esac

--- a/zram-config
+++ b/zram-config
@@ -472,7 +472,7 @@ case "$1" in
                     set -- $line
                     case "$1" in
                         dir|log)
-                            if [[ -z "$ONLY_TARGET" ]] || [[ $ONLY_TARGET == $3 ]]; then
+                            if [[ -z "$ONLY_TARGET" ]] || [[ $ONLY_TARGET == "$3" ]]; then
                                 ZRAM_DEV="$2"
                                 TARGET_DIR="$3"
                                 BIND_DIR="$(basename "$TARGET_DIR").bind"


### PR DESCRIPTION
Unwanted destinations can be skipped, if an explicit destination has been specified with an optional parameter.
E.g. for OpenHAB-Server to synchronize only the **persistence** folder.

Tested for the last 5 months.