### PR TITLE
Parameter added to suppress the service-restart if wanted

### DIFF
--- a/zram-config
+++ b/zram-config
@@ -472,7 +472,7 @@ case "$1" in
                             ZRAM_DEV="$2"
                             TARGET_DIR="$3"
                             BIND_DIR="$(basename "$TARGET_DIR").bind"
-                            [[ -z $SHUTDOWN ]] && ! [[ "${@,,}" =~ (^| )--noservicerestart($| ) ]] && serviceConfiguration "stop"
+                            [[ -z $SHUTDOWN ]] && ! [[ "${*,,}" =~ (^| )--noservicerestart($| ) ]] && serviceConfiguration "stop"
                             syncZdir
                             ;;
                     esac
@@ -487,6 +487,6 @@ case "$1" in
         exit 0
         ;;
 esac
-[[ -z $SHUTDOWN ]] && ! [[ "${@,,}" =~ (^| )--noservicerestart($| ) ]] && serviceConfiguration "start"
+[[ -z $SHUTDOWN ]] && ! [[ "${*,,}" =~ (^| )--noservicerestart($| ) ]] && serviceConfiguration "start"
 
 # vim: ts=4 sts=4 sw=4 et


### PR DESCRIPTION
- Parameter added to supress the service-restart if wanted
- Add a note for the new parameter to the scriptstart-help

The restart (stop & start) during sync can be explicitly prevented, if this isn't wanted (or better).
E.g. if only the OpenHAB persitence-folder should be synchronized.

Tested for the last 5 month.